### PR TITLE
Fix bug in ci/cd pipeline about listing files 

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -34,5 +34,5 @@ jobs:
 
     - name: Checking the code for formatting issues
       run: |
-          black --check --verbose $(git ls-files *.py)
+          black --check --verbose $(git ls-files '*.py')
         


### PR DESCRIPTION
Fix a bug where expansion was handled by the shell not by the `git ls-files` command, which made the command skip nested `.py` files. 

Solution: add single quotes around the pattern after `git ls-files` command. I.e., `'*.py'` instead of `*.py`

```
@@ -34,5 +35,5 @@
     - name: Checking the code for formatting issues
       run: |
-          black --check --verbose $(git ls-files *.py)
+          black --check --verbose $(git ls-files '*.py')
```

This change might introduce linter issues which will make the pipeline fail. Will follow up with a PR that handles them.