### PR TITLE
ci/cd: open-source compliance - copyright headers check

### DIFF
--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -85,3 +85,13 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking .typed files for copyright headers
+      run: |
+          count=$(git ls-files '*.typed' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.typed') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.typed') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -65,3 +65,13 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking .toml files for copyright headers
+      run: |
+          count=$(git ls-files '*.toml' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.toml') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.toml') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -46,3 +46,12 @@ jobs:
             exit 1
           fi
       
+    - name: Checking .md files for copyright headers
+      run: |
+          count=$(git ls-files '*.md' | wc -l)
+          count1=$(grep -Fx '<!-- Copyright (c) Microsoft Corporation.' $(git ls-files '*.md') | wc -l)
+          count2=$(grep -Fx ' Licensed under the MIT License. -->' $(git ls-files '*.md') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -6,7 +6,6 @@ name: Check for Copyright Headers
 on:
   push:
     branches:
-      - v-ghajam/open-source-compliance-copyright-headers-check
       - main
   pull_request:
     branches:

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -95,3 +95,14 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking .example files for copyright headers
+      run: |
+          count=$(git ls-files '*.example' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.example') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.example') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi
+  

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -35,3 +35,14 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking .cfg files for copyright headers
+      run: |
+          count=$(git ls-files '*.cfg' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.cfg') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.cfg') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi
+      

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -106,3 +106,12 @@ jobs:
             exit 1
           fi
   
+    - name: Checking .gitignore files for copyright headers
+      run: |
+          count=$(git ls-files '*.gitignore' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.gitignore') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.gitignore') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -75,3 +75,13 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking *requirements.txt files for copyright headers
+      run: |
+          count=$(git ls-files '*requirements.txt' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*requirements.txt') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*requirements.txt') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -55,3 +55,13 @@ jobs:
           then
             exit 1
           fi
+
+    - name: Checking .py files for copyright headers
+      run: |
+          count=$(git ls-files '*.py' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.py') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.py') | wc -l)
+          if (( $count != $count1 || $count != count2))
+          then
+            exit 1
+          fi

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -10,7 +10,6 @@ on:
       - main
   pull_request:
     branches:
-      - v-ghajam/open-source-compliance-copyright-headers-check
       - main
 
 jobs:
@@ -24,44 +23,15 @@ jobs:
             
     - name: Install dependencies
       run: |
-        sudo apt update -y && sudo apt install git -y
+        sudo apt update && sudo apt install git
         sudo apt install fd-find ripgrep
-
-    - name:  test
-      run: |
-        git ls-files *.py
-
-    - name: test2
-      run: |
-        git ls-files **/*.py
-    
-    - name: test3
-      run: |
-        git ls-files *.py **/*.py
-
-    - name: test4
-      run: |
-        git ls-files '*.py'
 
     - name: Checking .yml files for copyright headers
       run: |
-          echo 'Get Count of .yml files'
-          count=$(git ls-files *.yml | wc -l)
-          echo $count
-          if grep -Fx '# Copyright (c) Microsoft Corporation.\n# Licensed under the MIT License.' $(git ls-files *.yml) -eq $count
+          count=$(git ls-files '*.yml' | wc -l)
+          count1=$(grep -Fx '# Copyright (c) Microsoft Corporation.' $(git ls-files '*.yml') | wc -l)
+          count2=$(grep -Fx '# Licensed under the MIT License.' $(git ls-files '*.yml') | wc -l)
+          if (( $count != $count1 || $count != count2))
           then
-            echo 'Success'
-          else
-            echo 'FAIL'
+            exit 1
           fi
-        
-        #   11 cfg
-        #    1 example
-        #    1 gitignore
-        #    1 LICENSE
-        #   16 md
-        #  187 py
-        #   10 toml
-        #   13 txt
-        #    9 typed
-        #    5 yml

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Check for Copyright Headers
+
+on:
+  push:
+    branches:
+      - v-ghajam/open-source-compliance-copyright-headers-check
+      - main
+  pull_request:
+    branches:
+      - v-ghajam/open-source-compliance-copyright-headers-check
+      - main
+
+jobs:
+  copyright-headers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@v4
+            
+    - name: Install dependencies
+      run: |
+        sudo apt update -y && sudo apt install git -y
+        sudo apt install fd-find ripgrep
+
+    - name:  test
+      run: |
+        git ls-files *.py
+
+    - name: test2
+      run: |
+        git ls-files **/*.py
+    
+    - name: test3
+      run: |
+        git ls-files *.py **/*.py
+
+    - name: test4
+      run: |
+        git ls-files '*.py'
+
+    - name: Checking .yml files for copyright headers
+      run: |
+          echo 'Get Count of .yml files'
+          count=$(git ls-files *.yml | wc -l)
+          echo $count
+          if grep -Fx '# Copyright (c) Microsoft Corporation.\n# Licensed under the MIT License.' $(git ls-files *.yml) -eq $count
+          then
+            echo 'Success'
+          else
+            echo 'FAIL'
+          fi
+        
+        #   11 cfg
+        #    1 example
+        #    1 gitignore
+        #    1 LICENSE
+        #   16 md
+        #  187 py
+        #   10 toml
+        #   13 txt
+        #    9 typed
+        #    5 yml


### PR DESCRIPTION
Add an action checker for copyright headers for all current applicable file types.

- [x] .yml files
- [x] .cfg files
- [x] .md files
- [x] .py files
- [x] .toml files
- [x] requirements files
- [x] .typed == python typing files
- [x] .env.example files
- [x] .gitignore 