### PR TITLE
Security improvement: use full SHA commit in GitHub actions instead of tags

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
         

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -50,7 +50,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/copy_right_headers_check.yml
+++ b/.github/workflows/copy_right_headers_check.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
             
     - name: Install dependencies
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
         

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,10 +20,10 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
         


### PR DESCRIPTION
<!-- Copyright (c) Microsoft Corporation.
 Licensed under the MIT License. -->
<!--
IF SUFFICIENT INFORMATION IS NOT PROVIDED VIA THE FOLLOWING TEMPLATE THE REQUEST MIGHT BE CLOSED
-->
# Purpose

Improve Security by using full SHA commit in GitHub actions instead of **mutable tags**

## Problem / Scope

Tags are mutable, which introduces a potential attack surface if action's owner is compromised. Potentially creating a new malicious action under the same tag.

## Solution / Functionality

Use the commit SHA of the most recent release.

## Does this introduce a breaking change?

<!-- mark using x -->
- [ ] Yes
- [x] No

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other... Please describe:

Security improvement.

## Changes

### Affected Scenarios

None. updates are still tracked via Dependabot.