### PR TITLE
bug: (sdk samples) videosearch trending must specify datasource

### DIFF
--- a/samples/sdk/video_search_samples.py
+++ b/samples/sdk/video_search_samples.py
@@ -79,7 +79,7 @@ def video_trending(subscription_key):
     client = VideoSearchClient(AzureKeyCredential(SUBSCRIPTION_KEY))
 
     try:
-        trending_result = client.videos.trending(market='en-US')
+        trending_result = client.videos.trending(market="en-US")
         print("Search trending video")
 
         # Banner tiles

--- a/samples/sdk/video_search_samples.py
+++ b/samples/sdk/video_search_samples.py
@@ -79,7 +79,7 @@ def video_trending(subscription_key):
     client = VideoSearchClient(AzureKeyCredential(SUBSCRIPTION_KEY))
 
     try:
-        trending_result = client.videos.trending()
+        trending_result = client.videos.trending(market='en-US')
         print("Search trending video")
 
         # Banner tiles


### PR DESCRIPTION
<!-- Copyright (c) Microsoft Corporation.
 Licensed under the MIT License. -->
<!--
IF SUFFICIENT INFORMATION IS NOT PROVIDED VIA THE FOLLOWING TEMPLATE THE REQUEST MIGHT BE CLOSED
-->
# Purpose

Fix a bug in samples/sdk/videosearch, where the call for `trending` function returns an error about specifying a datasource. 

```json
{
  "_type": "ErrorResponse",
  "instrumentation": {
    "_type": "ResponseInstrumentation"
  },
  "errors": [
    {
      "code": "ServerError",
      "subCode": "ResourceError",
      "message": "",
      "moreDetails": "Please note the Data source and the Data source ErrorCode, then, for more information, refer to the HelpUrl.",
      "parameter": "Trending data is not present for your request"
    }
  ]
}
```

## Problem / Scope

SDK Samples - Video Search - the call for `trending`

## Solution / Functionality

Specify the `market` parameter as `"en-US"`

## Does this introduce a breaking change?

<!-- mark using x -->
- [ ] Yes
- [x] No

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Changes

### Affected Scenarios

The response is now valid Video search data instead of "error" response.

