### PR TITLE
bug: (sdk samples) newssearch invalid category

### DIFF
--- a/samples/sdk/news_search_samples.py
+++ b/samples/sdk/news_search_samples.py
@@ -91,9 +91,9 @@ def news_category(subscription_key):
 
     try:
         news_result = client.news.category(
-            category="Entertainment_MovieAndTV", market="en-us", safe_search="strict"
+            category="Entertainment", market="en-us", safe_search="strict"
         )
-        print("Search category news for movie and TV entertainment with safe search")
+        print("Search category news entertainment with safe search")
 
         if news_result.value:
             first_news_result = news_result.value[0]


### PR DESCRIPTION
<!-- Copyright (c) Microsoft Corporation.
 Licensed under the MIT License. -->
<!--
IF SUFFICIENT INFORMATION IS NOT PROVIDED VIA THE FOLLOWING TEMPLATE THE REQUEST MIGHT BE CLOSED
-->
# Purpose

Fix a bug in one NewsSearch SDK sample.

## Problem / Scope

The sample use an invalid category. `Entertainment_MovieAndTV`

## Solution / Functionality

Convert to `Entertainment` and update related line.

## Does this introduce a breaking change?

<!-- mark using x -->
- [ ] Yes
- [x] No

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Before Fix

```json
{
  "_type": "ErrorResponse",
  "errors": [
    {
      "code": "InvalidRequest",
      "subCode": "ParameterInvalidValue",
      "message": "Parameter has invalid value.",
      "moreDetails": "The category parameter is invalid.",
      "parameter": "category",
      "value": "Entertainment_MovieAndTV"
    }
  ]
}
```

## After Fix (Some fields removed)

```json
{
  "_type": "News",
  "webSearchUrl": "...",
  "value": [
    {
      "name": "20 years ago at the Emmys: Sharon Stone and William Shatner join forces",
      "url": "https://www.msn.com/en-us/entertainment/news/20-years-ago-at-the-emmys-sharon-stone-and-william-shatner-join-forces/ar-BB1qWWeK",
      "image": {
        "thumbnail": {
          "contentUrl": "...",
          "width": 840,
          "height": 560
        },
        "isLicensed": true
      },
      "description": "Creative Arts Awards at the Shrine Auditorium in Los Angeles to a room full of Oscar, Emmy, Grammy and Tony award winners — including one EGOT holder. \"The Practice\" swept the field for dramatic",
      "provider": [
        {
          "_type": "Organization",
          "name": "LA Times",
          "image": {
            "thumbnail": {
              "contentUrl": "..."
            }
          }
        }
      ],
      "datePublished": "..."
    },
   // multiple other results
  ...
  ]
}
```